### PR TITLE
Avoid referencing missing PreviewAppInitializer.g.cs

### DIFF
--- a/src/platforms/HotPreview.App.Maui/build/HotPreview.App.Maui.targets
+++ b/src/platforms/HotPreview.App.Maui/build/HotPreview.App.Maui.targets
@@ -9,7 +9,7 @@
       ProjectPath="$(MSBuildProjectFullPath)"
       OutputPath="$(IntermediateOutputPath)PreviewAppInitializer.g.cs"
       PlatformPreviewApplication="HotPreview.App.Maui.MauiPreviewApplication.Instance" />
-    <ItemGroup>
+    <ItemGroup Condition="Exists('$(IntermediateOutputPath)PreviewAppInitializer.g.cs')">
       <Compile Include="$(IntermediateOutputPath)PreviewAppInitializer.g.cs" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
## Summary
- only include PreviewAppInitializer.g.cs in compilation when the file exists

## Testing
- `dotnet test test/HotPreview.Tooling.Tests/HotPreview.Tooling.Tests.csproj -c Release -p:EnableWindowsTargeting=true` *(fails: ADB is not installed or not in PATH; user32.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944da70588832eaf6b67904fdf0af5